### PR TITLE
Enable reading of vertex normals in PLY files

### DIFF
--- a/src/meshio.h
+++ b/src/meshio.h
@@ -23,8 +23,8 @@ load_mesh_or_pointcloud(const std::string &filename, MatrixXu &F,
 extern void load_obj(const std::string &filename, MatrixXu &F, MatrixXf &V,
                      const ProgressCallback &progress = ProgressCallback());
 
-extern void load_ply(const std::string &filename, MatrixXu &F, MatrixXf &V,
-                     bool load_faces = true,
+extern void load_ply(const std::string &filename, MatrixXu &F, MatrixXf &V, 
+                     MatrixXf &N, bool load_faces = true,
                      const ProgressCallback &progress = ProgressCallback());
 
 extern void


### PR DESCRIPTION
This modifies the load_ply function and passes in the normal matrix. If no faces are found in the file, it will attempt to read in vertex normals from the PLY file (labelled nx, ny, nz). This has been tested against all the [example files] (https://s3.eu-central-1.amazonaws.com/instant-meshes/instant-meshes-datasets.zip) and the [aln format] (https://www.mitsuba-renderer.org/files/repository/gargoyle.zip). 