### PR TITLE
Orientation comb and Edge brush tools bugfix

### DIFF
--- a/src/smoothcurve.cpp
+++ b/src/smoothcurve.cpp
@@ -161,7 +161,7 @@ inline bool astar(const MatrixXu &F, const VectorXu &E2E, const MatrixXf &V, uin
     };
 
     auto eucldist = [&](uint32_t i, uint32_t j) -> Float {
-        Vector3f diff;
+        Vector3f diff = Vector3f::Zero();
         for (uint32_t k=0; k<3; ++k)
             diff += V.col(F(k, i)) - V.col(F(k, j));
         return diff.norm() * (1.0f / 3.0f);


### PR DESCRIPTION
astar function returned false always because diff variable was not initialized which resulted in NaN. Tested on Ubuntu 18.04.3 and Orientation comb and Edge brush tools work fine now.