### PR TITLE
Fix memory leaks due to raw pointers created with 'new'.

### DIFF
--- a/src/adjacency.cpp
+++ b/src/adjacency.cpp
@@ -20,11 +20,53 @@
 #include "dset.h"
 #include <set>
 #include <map>
+#include <numeric>
+#include <parallel_stable_sort.h>
 
-AdjacencyMatrix generate_adjacency_matrix_uniform(
-    const MatrixXu &F, const VectorXu &V2E, const VectorXu &E2E,
-    const VectorXb &nonManifold, const ProgressCallback &progress) {
-    VectorXu neighborhoodSize(V2E.size() + 1);
+AdjacencyMatrix::AdjacencyMatrix(
+    const std::vector<std::vector<uint32_t>>& adj_id,
+    const std::vector<std::vector<uint32_t>>& adj_ivar,
+    const std::vector<std::vector<Float>>& adj_weight)
+{
+    uint32_t linkCount = 0;
+
+    if (adj_id.size() != adj_ivar.size() || adj_ivar.size() != adj_weight.size())
+            throw std::runtime_error("Could not unserialize data");
+
+    for (uint32_t j=0; j<adj_id.size(); ++j) {
+        if (adj_id[j].size() != adj_ivar[j].size() || adj_ivar[j].size() != adj_weight[j].size())
+            throw std::runtime_error("Could not unserialize data");
+        linkCount += adj_id[j].size();
+    }
+
+    mRows.resize(adj_id.size() + 1);
+    mLinks.resize(linkCount);
+
+    mRows[0] = mLinks.data();
+    for (uint32_t i=0; i < adj_id.size(); ++i)
+    {
+        mRows[i+1] = mRows[i] + adj_id[i].size();
+    }
+
+    for (uint32_t j=0; j<adj_id.size(); ++j)
+    {
+        for (uint32_t k=0; k<adj_id[j].size(); ++k)
+        {
+            mRows[j][k].id = adj_id[j][k];
+            mRows[j][k].ivar_uint32 = adj_ivar[j][k];
+            mRows[j][k].weight = adj_weight[j][k];
+        }
+    }
+}
+
+AdjacencyMatrix::AdjacencyMatrix(
+    const MatrixXu& F,
+    const VectorXu& V2E,
+    const VectorXu& E2E,
+    const VectorXb& nonManifold,
+    const ProgressCallback& progress)
+{
+    std::vector<uint32_t> adjacencySizes(V2E.size());
     cout << "Generating adjacency matrix .. ";
     cout.flush();
     Timer<> timer;
@@ -35,7 +77,7 @@ AdjacencyMatrix generate_adjacency_matrix_uniform(
             for (uint32_t i = range.begin(); i != range.end(); ++i) {
                 uint32_t edge = V2E[i], stop = edge;
                 if (nonManifold[i] || edge == INVALID) {
-                    neighborhoodSize[i+1] = 0;
+                    adjacencySizes[i] = 0;
                     continue;
                 }
                 uint32_t nNeighbors = 0;
@@ -48,21 +90,22 @@ AdjacencyMatrix generate_adjacency_matrix_uniform(
                     edge = dedge_next_3(opp);
                     nNeighbors++;
                 } while (edge != stop);
-                neighborhoodSize[i+1] = nNeighbors;
+                adjacencySizes[i] = nNeighbors;
             }
             SHOW_PROGRESS_RANGE(range, V2E.size(), "Generating adjacency matrix (1/2)");
         }
     );
 
-    neighborhoodSize[0] = 0;
-    for (uint32_t i=0; i<neighborhoodSize.size()-1; ++i)
-        neighborhoodSize[i+1] += neighborhoodSize[i];
+    const uint32_t linkCount = std::accumulate(adjacencySizes.begin(), adjacencySizes.end(), 0);
 
-    AdjacencyMatrix adj = new Link*[V2E.size() + 1];
-    uint32_t nLinks = neighborhoodSize[neighborhoodSize.size()-1];
-    Link *links = new Link[nLinks];
-    for (uint32_t i=0; i<neighborhoodSize.size(); ++i)
-        adj[i] = links + neighborhoodSize[i];
+    mRows.resize(adjacencySizes.size() + 1);
+    mLinks.resize(linkCount);
+
+    mRows[0] = mLinks.data();
+    for (uint32_t i=0; i < adjacencySizes.size(); ++i)
+    {
+        mRows[i+1] = mRows[i] + adjacencySizes[i];
+    }
 
     tbb::parallel_for(
         tbb::blocked_range<uint32_t>(0u, (uint32_t) V2E.size(), GRAIN_SIZE),
@@ -71,7 +114,7 @@ AdjacencyMatrix generate_adjacency_matrix_uniform(
                 uint32_t edge = V2E[i], stop = edge;
                 if (nonManifold[i] || edge == INVALID)
                     continue;
-                Link *ptr = adj[i];
+                Link *ptr = mRows[i];
 
                 int it = 0;
                 do {
@@ -93,16 +136,17 @@ AdjacencyMatrix generate_adjacency_matrix_uniform(
     );
 
     cout << "done. (took " << timeString(timer.value()) << ")" << endl;
-
-    return adj;
 }
 
-AdjacencyMatrix
-generate_adjacency_matrix_cotan(const MatrixXu &F, const MatrixXf &V,
-                                const VectorXu &V2E, const VectorXu &E2E,
-                                const VectorXb &nonManifold,
-                                const ProgressCallback &progress) {
-    VectorXu neighborhoodSize(V2E.size() + 1);
+AdjacencyMatrix::AdjacencyMatrix(
+    const MatrixXu& F,
+    const MatrixXf& V,
+    const VectorXu& V2E,
+    const VectorXu& E2E,
+    const VectorXb& nonManifold,
+    const ProgressCallback& progress)
+{
+    std::vector<uint32_t> adjacencySizes(V2E.size());
     cout << "Computing cotangent Laplacian .. ";
     cout.flush();
     Timer<> timer;
@@ -113,7 +157,7 @@ generate_adjacency_matrix_cotan(const MatrixXu &F, const MatrixXf &V,
             for (uint32_t i = range.begin(); i != range.end(); ++i) {
                 uint32_t edge = V2E[i], stop = edge;
                 if (nonManifold[i] || edge == INVALID) {
-                    neighborhoodSize[i+1] = 0;
+                    adjacencySizes[i] = 0;
                     continue;
                 }
                 uint32_t nNeighbors = 0;
@@ -126,21 +170,22 @@ generate_adjacency_matrix_cotan(const MatrixXu &F, const MatrixXf &V,
                     edge = dedge_next_3(opp);
                     nNeighbors++;
                 } while (edge != stop);
-                neighborhoodSize[i+1] = nNeighbors;
+                adjacencySizes[i] = nNeighbors;
             }
             SHOW_PROGRESS_RANGE(range, V2E.size(), "Computing cotangent Laplacian (1/2)");
         }
     );
 
-    neighborhoodSize[0] = 0;
-    for (uint32_t i=0; i<neighborhoodSize.size()-1; ++i)
-        neighborhoodSize[i+1] += neighborhoodSize[i];
+    const uint32_t linkCount = std::accumulate(adjacencySizes.begin(), adjacencySizes.end(), 0);
 
-    AdjacencyMatrix adj = new Link*[V2E.size() + 1];
-    uint32_t nLinks = neighborhoodSize[neighborhoodSize.size()-1];
-    Link *links = new Link[nLinks];
-    for (uint32_t i=0; i<neighborhoodSize.size(); ++i)
-        adj[i] = links + neighborhoodSize[i];
+    mRows.resize(adjacencySizes.size() + 1);
+    mLinks.resize(linkCount);
+
+    mRows[0] = mLinks.data();
+    for (uint32_t i=0; i < adjacencySizes.size(); ++i)
+    {
+        mRows[i+1] = mRows[i] + adjacencySizes[i];
+    }
 
     tbb::parallel_for(
         tbb::blocked_range<uint32_t>(0u, (uint32_t)V.cols(), GRAIN_SIZE),
@@ -149,7 +194,7 @@ generate_adjacency_matrix_cotan(const MatrixXu &F, const MatrixXf &V,
                 uint32_t edge = V2E[i], stop = edge;
                 if (nonManifold[i] || edge == INVALID)
                     continue;
-                Link *ptr = adj[i];
+                Link *ptr = mRows[i];
 
                 int it = 0;
                 do {
@@ -215,23 +260,29 @@ generate_adjacency_matrix_cotan(const MatrixXu &F, const MatrixXf &V,
         }
     );
     cout << "done. (took " << timeString(timer.value()) << ")" << endl;
-    return adj;
 }
 
-AdjacencyMatrix generate_adjacency_matrix_pointcloud(
-    MatrixXf &V, MatrixXf &N, const BVH *bvh, MeshStats &stats, uint32_t knn_points,
-    bool deterministic, const ProgressCallback &progress) {
+AdjacencyMatrix::AdjacencyMatrix(
+    MatrixXf &V,
+    MatrixXf &N,
+    const BVH& bvh,
+    MeshStats &stats,
+    uint32_t knn_points,
+    bool deterministic,
+    const ProgressCallback &progress)
+{
     Timer<> timer;
     cout << "Generating adjacency matrix .. ";
     cout.flush();
 
-    stats.mAverageEdgeLength = bvh->diskRadius();
-    const Float maxQueryRadius = bvh->diskRadius() * 3;
+    stats.mAverageEdgeLength = bvh.diskRadius();
+    const Float maxQueryRadius = bvh.diskRadius() * 3;
 
-    uint32_t *adj_sets = new uint32_t[V.cols() * (size_t) knn_points];
+    std::vector<uint32_t> adjacencySets(V.cols() * knn_points);
+    auto adj_sets = adjacencySets.data();
 
     DisjointSets dset(V.cols());
-    VectorXu adj_size(V.cols());
+    std::vector<uint32_t> adjacencySizes(V.cols());
     tbb::parallel_for(
         tbb::blocked_range<uint32_t>(0u, (uint32_t) V.cols(), GRAIN_SIZE),
         [&](const tbb::blocked_range<uint32_t> &range) {
@@ -240,7 +291,7 @@ AdjacencyMatrix generate_adjacency_matrix_pointcloud(
                 uint32_t *adj_set = adj_sets + (size_t) i * (size_t) knn_points;
                 memset(adj_set, 0xFF, sizeof(uint32_t) * knn_points);
                 Float radius = maxQueryRadius;
-                bvh->findKNearest(V.col(i), N.col(i), knn_points, radius, result);
+                bvh.findKNearest(V.col(i), N.col(i), knn_points, radius, result);
                 uint32_t ctr = 0;
                 for (auto k : result) {
                     if (k.second == i)
@@ -248,7 +299,7 @@ AdjacencyMatrix generate_adjacency_matrix_pointcloud(
                     adj_set[ctr++] = k.second;
                     dset.unite(k.second, i);
                 }
-                adj_size[i] = ctr;
+                adjacencySizes[i] = ctr;
             }
             SHOW_PROGRESS_RANGE(range, V.cols(), "Generating adjacency matrix");
         }
@@ -271,31 +322,44 @@ AdjacencyMatrix generate_adjacency_matrix_pointcloud(
                 if (value == INVALID) break;
             }
             if (!found)
-                adj_size[k]++;
+                adjacencySizes[k]++;
         }
     }
 
-    size_t nLinks = 0;
-    for (uint32_t i=0; i<V.cols(); ++i) {
-        uint32_t dsetSize = dset_size[dset.find(i)];
-        if (dsetSize < V.cols() * 0.01f) {
-            adj_size[i] = INVALID;
+    size_t linkCount = 0;
+    for (uint32_t i=0; i<V.cols(); ++i)
+    {
+        const uint32_t dsetSize = dset_size[dset.find(i)];
+        uint32_t& adjacencySize = adjacencySizes[i];
+        if (dsetSize < V.cols() * 0.01f)
+        {
+            adjacencySize = INVALID;
             V.col(i) = Vector3f::Constant(1e6);
-            continue;
         }
-        nLinks += adj_size[i];
+        else
+        {
+            linkCount += adjacencySize;
+        }
     }
 
-    cout << "allocating " << memString(sizeof(Link) * nLinks) << " .. ";
+    cout << "allocating " << memString(sizeof(Link) * linkCount) << " .. ";
     cout.flush();
 
-    AdjacencyMatrix adj = new Link*[V.size() + 1];
-    adj[0] = new Link[nLinks];
-    for (uint32_t i=1; i<=V.cols(); ++i) {
-        uint32_t size = adj_size[i-1];
+    mRows.resize(adjacencySizes.size() + 1);
+    mLinks.resize(linkCount);
+    mRows[0] = mLinks.data();
+
+    for (uint32_t i=0; i < adjacencySizes.size(); ++i)
+    {
+        const uint32_t size = adjacencySizes[i];
         if (size == INVALID)
-            size = 0;
-        adj[i] = adj[i-1] + size;
+        {
+            mRows[i+1] = mRows[i];
+        }
+        else
+        {
+            mRows[i+1] = mRows[i] + size;
+        }
     }
 
     VectorXu adj_offset(V.cols());
@@ -306,14 +370,14 @@ AdjacencyMatrix generate_adjacency_matrix_pointcloud(
         [&](const tbb::blocked_range<uint32_t> &range) {
             for (uint32_t i = range.begin(); i < range.end(); ++i) {
                 uint32_t *adj_set_i = adj_sets + (size_t) i * (size_t) knn_points;
-                if (adj_size[i] == INVALID)
+                if (adjacencySizes[i] == INVALID)
                     continue;
 
                 for (uint32_t j=0; j<knn_points; ++j) {
                     uint32_t k = adj_set_i[j];
                     if (k == INVALID)
                         break;
-                    adj[i][atomicAdd(&adj_offset.coeffRef(i), 1)-1] = Link(k);
+                    mRows[i][atomicAdd(&adj_offset.coeffRef(i), 1)-1] = Link(k);
 
                     uint32_t *adj_set_k = adj_sets + (size_t) k * (size_t) knn_points;
                     bool found = false;
@@ -323,7 +387,7 @@ AdjacencyMatrix generate_adjacency_matrix_pointcloud(
                         if (value == INVALID) break;
                     }
                     if (!found)
-                        adj[k][atomicAdd(&adj_offset.coeffRef(k), 1)-1] = Link(i);
+                        mRows[k][atomicAdd(&adj_offset.coeffRef(k), 1)-1] = Link(i);
                 }
             }
         }
@@ -335,5 +399,197 @@ AdjacencyMatrix generate_adjacency_matrix_pointcloud(
     stats.mSurfaceArea = M_PI * stats.mAverageEdgeLength*stats.mAverageEdgeLength * 0.5f * V.cols();
 
     cout << "done. (took " << timeString(timer.value()) << ")" << endl;
-    return adj;
+}
+
+AdjacencyMatrix::AdjacencyMatrix(
+    const AdjacencyMatrix& adj,
+    const MatrixXf &V,
+    const MatrixXf &N,
+    const VectorXf &A,
+    MatrixXf& V_p,
+    MatrixXf& N_p,
+    VectorXf& A_p,
+    MatrixXu& to_upper,
+    VectorXu& to_lower,
+    bool deterministic,
+    const ProgressCallback &progress)
+{
+    struct Entry {
+        uint32_t i, j;
+        float order;
+        inline Entry() { };
+        inline Entry(uint32_t i, uint32_t j, float order) : i(i), j(j), order(order) { }
+        inline bool operator<(const Entry &e) const { return order > e.order; }
+    };
+
+    uint32_t nLinks = adj[V.cols()] - adj[0];
+    std::vector<Entry> entryBuffer(nLinks);
+    Entry* entries = entryBuffer.data();
+    Timer<> timer;
+    cout << "  Collapsing .. ";
+    cout.flush();
+
+    tbb::parallel_for(
+        tbb::blocked_range<uint32_t>(0u, (uint32_t) V.cols(), GRAIN_SIZE),
+        [&](const tbb::blocked_range<uint32_t> &range) {
+            for (uint32_t i = range.begin(); i != range.end(); ++i) {
+                uint32_t nNeighbors = adj[i + 1] - adj[i];
+                uint32_t base = adj[i] - adj[0];
+                for (uint32_t j = 0; j < nNeighbors; ++j) {
+                    uint32_t k = adj[i][j].id;
+                    Float dp = N.col(i).dot(N.col(k));
+                    Float ratio = A[i]>A[k] ? (A[i]/A[k]) : (A[k]/A[i]);
+                    entries[base + j] = Entry(i, k, dp * ratio);
+                }
+            }
+            SHOW_PROGRESS_RANGE(range, V.cols(), "Downsampling graph (1/6)");
+        }
+    );
+
+    if (progress)
+        progress("Downsampling graph (2/6)", 0.0f);
+
+    if (deterministic)
+        pss::parallel_stable_sort(entries, entries + nLinks, std::less<Entry>());
+    else
+        tbb::parallel_sort(entries, entries + nLinks, std::less<Entry>());
+
+    std::vector<bool> mergeFlag(V.cols(), false);
+
+    uint32_t nCollapsed = 0;
+    for (uint32_t i=0; i<nLinks; ++i) {
+        const Entry &e = entries[i];
+        if (mergeFlag[e.i] || mergeFlag[e.j])
+            continue;
+        mergeFlag[e.i] = mergeFlag[e.j] = true;
+        entries[nCollapsed++] = entries[i];
+    }
+    uint32_t vertexCount = V.cols() - nCollapsed;
+
+    /* Allocate memory for coarsened graph */
+    V_p.resize(3, vertexCount);
+    N_p.resize(3, vertexCount);
+    A_p.resize(vertexCount);
+    to_upper.resize(2, vertexCount);
+    to_lower.resize(V.cols());
+
+    tbb::parallel_for(
+        tbb::blocked_range<uint32_t>(0u, (uint32_t) nCollapsed, GRAIN_SIZE),
+        [&](const tbb::blocked_range<uint32_t> &range) {
+            for (uint32_t i = range.begin(); i != range.end(); ++i) {
+                const Entry &e = entries[i];
+                const Float area1 = A[e.i], area2 = A[e.j], surfaceArea = area1+area2;
+                if (surfaceArea > RCPOVERFLOW)
+                    V_p.col(i) = (V.col(e.i) * area1 + V.col(e.j) * area2) / surfaceArea;
+                else
+                    V_p.col(i) = (V.col(e.i) + V.col(e.j)) * 0.5f;
+                Vector3f normal = N.col(e.i) * area1 + N.col(e.j) * area2;
+                Float norm = normal.norm();
+                N_p.col(i) = norm > RCPOVERFLOW ? Vector3f(normal / norm)
+                                                : Vector3f::UnitX();
+                A_p[i] = surfaceArea;
+                to_upper.col(i) << e.i, e.j;
+                to_lower[e.i] = i; to_lower[e.j] = i;
+            }
+            SHOW_PROGRESS_RANGE(range, nCollapsed, "Downsampling graph (3/6)");
+        }
+    );
+
+    std::atomic<int> offset(nCollapsed);
+    tbb::blocked_range<uint32_t> range(0u, (uint32_t) V.cols(), GRAIN_SIZE);
+
+    auto copy_uncollapsed = [&](const tbb::blocked_range<uint32_t> &range) {
+        for (uint32_t i = range.begin(); i != range.end(); ++i) {
+            if (!mergeFlag[i]) {
+                uint32_t idx = offset++;
+                V_p.col(idx) = V.col(i);
+                N_p.col(idx) = N.col(i);
+                A_p[idx] = A[i];
+                to_upper.col(idx) << i, INVALID;
+                to_lower[i] = idx;
+            }
+        }
+        SHOW_PROGRESS_RANGE(range, V.cols(), "Downsampling graph (4/6)");
+    };
+
+    if (deterministic)
+        copy_uncollapsed(range);
+    else
+        tbb::parallel_for(range, copy_uncollapsed);
+
+    std::vector<uint32_t> adjacencySizes(V_p.cols());
+
+    tbb::parallel_for(
+        tbb::blocked_range<uint32_t>(0u, (uint32_t) V_p.cols(), GRAIN_SIZE),
+        [&](const tbb::blocked_range<uint32_t> &range) {
+            std::vector<Link> scratch;
+            for (uint32_t i = range.begin(); i != range.end(); ++i) {
+                scratch.clear();
+
+                for (int j=0; j<2; ++j) {
+                    uint32_t upper = to_upper(j, i);
+                    if (upper == INVALID)
+                        continue;
+                    for (Link *link = adj[upper]; link != adj[upper+1]; ++link)
+                        scratch.push_back(Link(to_lower[link->id], link->weight));
+                }
+
+                std::sort(scratch.begin(), scratch.end());
+                uint32_t id = INVALID, size = 0;
+                for (const auto &link : scratch) {
+                    if (id != link.id && link.id != i) {
+                        id = link.id;
+                        ++size;
+                    }
+                }
+                adjacencySizes[i] = size;
+            }
+            SHOW_PROGRESS_RANGE(range, V_p.cols(), "Downsampling graph (5/6)");
+        }
+    );
+
+    const uint32_t linkCount = std::accumulate(adjacencySizes.begin(), adjacencySizes.end(), 0);
+
+    mRows.resize(adjacencySizes.size() + 1);
+    mLinks.resize(linkCount);
+
+    mRows[0] = mLinks.data();
+    for (uint32_t i=0; i < adjacencySizes.size(); ++i)
+    {
+        mRows[i+1] = mRows[i] + adjacencySizes[i];
+    }
+
+    tbb::parallel_for(
+        tbb::blocked_range<uint32_t>(0u, (uint32_t) V_p.cols(), GRAIN_SIZE),
+        [&](const tbb::blocked_range<uint32_t> &range) {
+            std::vector<Link> scratch;
+            for (uint32_t i = range.begin(); i != range.end(); ++i) {
+                scratch.clear();
+
+                for (int j=0; j<2; ++j) {
+                    uint32_t upper = to_upper(j, i);
+                    if (upper == INVALID)
+                        continue;
+                    for (Link *link = adj[upper]; link != adj[upper+1]; ++link)
+                        scratch.push_back(Link(to_lower[link->id], link->weight));
+                }
+                std::sort(scratch.begin(), scratch.end());
+                Link *dest = mRows[i];
+                uint32_t id = INVALID;
+                for (const auto &link : scratch) {
+                    if (link.id != i) {
+                        if (id != link.id) {
+                            *dest++ = link;
+                            id = link.id;
+                        } else {
+                            dest[-1].weight += link.weight;
+                        }
+                    }
+                }
+            }
+            SHOW_PROGRESS_RANGE(range, V_p.cols(), "Downsampling graph (6/6)");
+        }
+    );
+    cout << "done. (" << V.cols() << " -> " << V_p.cols() << " vertices, took "
+         << timeString(timer.value()) << ")" << endl;
 }

--- a/src/adjacency.h
+++ b/src/adjacency.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "common.h"
+#include <cstdint>
 
 /* Stores integer jumps between nodes of the adjacency matrix */
 struct IntegerVariable {
@@ -47,19 +48,91 @@ struct Link {
     inline Link(uint32_t id, float weight) : id(id), weight(weight), ivar_uint32(0u) { }
 
     inline bool operator<(const Link &link) const { return id < link.id; }
-} ;
+};
 
-typedef Link** AdjacencyMatrix;
+class BVH;
+struct MeshStats;
 
-extern AdjacencyMatrix generate_adjacency_matrix_uniform(
-    const MatrixXu &F, const VectorXu &V2E,
-    const VectorXu &E2E, const VectorXb &nonManifold,
-    const ProgressCallback &progress = ProgressCallback());
+class AdjacencyMatrix
+{
+public:
+    /* Default constructor. */
+    AdjacencyMatrix(){}
 
-extern AdjacencyMatrix generate_adjacency_matrix_cotan(
-    const MatrixXu &F, const MatrixXf &V, const VectorXu &V2E,
-    const VectorXu &E2E, const VectorXb &nonManifold,
-    const ProgressCallback &progress = ProgressCallback());
+    /* Create adjancency matrix from loaded serialized data. */
+    AdjacencyMatrix(
+        const std::vector<std::vector<uint32_t>>& adj_id,
+        const std::vector<std::vector<uint32_t>>& adj_ivar,
+        const std::vector<std::vector<Float>>& adj_weight);
+
+    /* Create adjancency matrix from a mesh. */
+    AdjacencyMatrix(
+        const MatrixXu &F,
+        const VectorXu &V2E,
+        const VectorXu &E2E,
+        const VectorXb &nonManifold,
+        const ProgressCallback &progress = ProgressCallback());
+
+    /* Create adjancency matrix from a mesh using cotangent laplacian. */
+    AdjacencyMatrix(
+        const MatrixXu &F,
+        const MatrixXf &V,
+        const VectorXu &V2E,
+        const VectorXu &E2E,
+        const VectorXb &nonManifold,
+        const ProgressCallback &progress = ProgressCallback());
+
+    /* Create adjancency matrix from a point cloud. */
+    AdjacencyMatrix(
+        MatrixXf &V,
+        MatrixXf &N,
+        const BVH& bvh,
+        MeshStats &stats,
+        uint32_t knn_points,
+        bool deterministic = false,
+        const ProgressCallback &progress = ProgressCallback());
+
+    /* Create adjancency from a downsampled graph. */
+    AdjacencyMatrix(
+        const AdjacencyMatrix& adj,
+        const MatrixXf& V,
+        const MatrixXf& N,
+        const VectorXf& areas,
+        MatrixXf& V_p,
+        MatrixXf& V_n,
+        VectorXf& areas_p,
+        MatrixXu& to_upper,
+        VectorXu& to_lower,
+        bool deterministic = false,
+        const ProgressCallback& progress = ProgressCallback());
+
+    /* Move constructor. */
+    AdjacencyMatrix(AdjacencyMatrix&& other) : mLinks(std::move(other.mLinks)), mRows(std::move(other.mRows)) {}
+
+    /* Move assignment. */
+    AdjacencyMatrix& operator=(AdjacencyMatrix&& other)
+    {
+        mLinks = std::move(other.mLinks);
+        mRows = std::move(other.mRows);
+        return *this;
+    }
+
+    /* Disable copy constructor. */
+    AdjacencyMatrix(const AdjacencyMatrix& other) = delete;
+
+    /* Disable copy assignment. */
+    AdjacencyMatrix& operator=(const AdjacencyMatrix& other) = delete;
+
+    /* Element access. */
+    Link* operator[] (size_t index) const { return mRows[index]; }
+
+    const std::vector<Link>& Links() const { return mLinks; }
+    const std::vector<Link*>& Rows() const { return mRows; }
+
+private:
+    std::vector<Link> mLinks;
+    std::vector<Link*> mRows;
+};
 
 inline Link &search_adjacency(AdjacencyMatrix &adj, uint32_t i, uint32_t j) {
     for (Link* l = adj[i]; l != adj[i+1]; ++l)
@@ -68,10 +141,3 @@ inline Link &search_adjacency(AdjacencyMatrix &adj, uint32_t i, uint32_t j) {
     throw std::runtime_error("search_adjacency: failure!");
 }
 
-class BVH;
-struct MeshStats;
-
-extern AdjacencyMatrix generate_adjacency_matrix_pointcloud(
-    MatrixXf &V, MatrixXf &N, const BVH *bvh, MeshStats &stats,
-    uint32_t knn_points, bool deterministic = false,
-    const ProgressCallback &progress = ProgressCallback());

--- a/src/batch.h
+++ b/src/batch.h
@@ -19,4 +19,5 @@ extern void batch_process(const std::string &input, const std::string &output,
                           int rosy, int posy, Float scale, int face_count,
                           int vertex_count, Float creaseAngle, bool extrinsic,
                           bool align_to_boundaries, int smooth_iter,
-                          int knn_points, bool dominant, bool deterministic);
+                          int knn_points, bool dominant, bool deterministic, int concurrency = -1);
+

--- a/src/extract.cpp
+++ b/src/extract.cpp
@@ -518,7 +518,7 @@ extract_graph(const MultiResolutionHierarchy &mRes, bool extrinsic, int rosy, in
 void extract_faces(std::vector<std::vector<TaggedLink> > &adj, MatrixXf &O,
                    MatrixXf &N, MatrixXf &Nf, MatrixXu &F, int posy,
                    Float scale, std::set<uint32_t> &crease, bool fill_holes,
-                   bool pure_quad, BVH *bvh, int smooth_iterations) {
+                   bool pure_quad, const BVH& bvh, int smooth_iterations) {
 
     uint32_t nF = 0, nV = O.cols(), nV_old = O.cols();
     F.resize(posy, posy == 4 ? O.cols() : O.cols()*2);
@@ -907,6 +907,8 @@ void extract_faces(std::vector<std::vector<TaggedLink> > &adj, MatrixXf &O,
             }
         );
 
+        const bool bvhHasFaces = bvh.hasFaces();
+
         for (int it=0; it<smooth_iterations; ++it) {
             MatrixXf O_prime(O.rows(), O.cols());
             MatrixXf N_prime(O.rows(), O.cols());
@@ -933,13 +935,13 @@ void extract_faces(std::vector<std::vector<TaggedLink> > &adj, MatrixXf &O,
                             Vector3f n = cov.jacobiSvd(Eigen::ComputeFullU).matrixU().col(2).normalized();
                             n *= signum(avgNormal.dot(n));
 
-                            if (bvh && bvh->F()->size() > 0) {
+                            if (bvhHasFaces) {
                                 Ray ray1(centroid,  n, 0, scale / 2);
                                 Ray ray2(centroid, -n, 0, scale / 2);
                                 uint32_t idx1 = 0, idx2 = 0;
                                 Float t1 = 0, t2 = 0;
-                                bvh->rayIntersect(ray1, idx1, t1);
-                                bvh->rayIntersect(ray2, idx2, t2);
+                                bvh.rayIntersect(ray1, idx1, t1);
+                                bvh.rayIntersect(ray2, idx2, t2);
                                 if (std::min(t1, t2) < scale*0.5f)
                                     centroid = t1 < t2 ? ray1(t1) : ray2(t2);
                             }

--- a/src/extract.h
+++ b/src/extract.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "hierarchy.h"
+#include "bvh.h"
 #include <set>
 
 struct TaggedLink {
@@ -23,8 +24,6 @@ struct TaggedLink {
     bool used() const { return flag & 1; }
     void markUsed() { flag |= 1; }
 };
-
-class BVH;
 
 extern void
 extract_graph(const MultiResolutionHierarchy &mRes, bool extrinsic, int rosy, int posy,
@@ -40,4 +39,4 @@ extern void extract_faces(std::vector<std::vector<TaggedLink> > &adj,
                           MatrixXf &O, MatrixXf &N, MatrixXf &Nf, MatrixXu &F,
                           int posy, Float scale, std::set<uint32_t> &crease,
                           bool fill_holes = true, bool pure_quad = true,
-                          BVH *bvh = nullptr, int smooth_iterations = 2);
+                          const BVH& bvh = BVH(), int smooth_iterations = 2);

--- a/src/field.h
+++ b/src/field.h
@@ -156,7 +156,14 @@ compute_position_singularities(const MultiResolutionHierarchy &mRes,
 class Serializer;
 class Optimizer {
 public:
-    Optimizer(MultiResolutionHierarchy &mRes, bool interactive);
+    Optimizer(MultiResolutionHierarchy &mRes, bool interactive = false, int concurrency = -1);
+    ~Optimizer() { if (mThread.joinable()) shutdown(); }
+
+    Optimizer(Optimizer&& other) = delete;
+    Optimizer& operator=(Optimizer&& other) = delete;
+    Optimizer(const Optimizer& other) = delete;
+    Optimizer& operator=(const Optimizer& other) = delete;
+
     void save(Serializer &state);
     void load(const Serializer &state);
 
@@ -219,4 +226,5 @@ protected:
     VectorXf mError;
 #endif
     Timer<> mTimer;
+    int mConcurrency;
 };

--- a/src/hierarchy.cpp
+++ b/src/hierarchy.cpp
@@ -16,195 +16,7 @@
 #include "serializer.h"
 #include "dedge.h"
 #include "field.h"
-#include <parallel_stable_sort.h>
 #include <pcg32.h>
-
-AdjacencyMatrix downsample_graph(const AdjacencyMatrix adj, const MatrixXf &V,
-                                 const MatrixXf &N, const VectorXf &A,
-                                 MatrixXf &V_p, MatrixXf &N_p, VectorXf &A_p,
-                                 MatrixXu &to_upper, VectorXu &to_lower,
-                                 bool deterministic,
-                                 const ProgressCallback &progress) {
-    struct Entry {
-        uint32_t i, j;
-        float order;
-        inline Entry() { };
-        inline Entry(uint32_t i, uint32_t j, float order) : i(i), j(j), order(order) { }
-        inline bool operator<(const Entry &e) const { return order > e.order; }
-    };
-
-    uint32_t nLinks = adj[V.cols()] - adj[0];
-    Entry *entries = new Entry[nLinks];
-    Timer<> timer;
-    cout << "  Collapsing .. ";
-    cout.flush();
-
-    tbb::parallel_for(
-        tbb::blocked_range<uint32_t>(0u, (uint32_t) V.cols(), GRAIN_SIZE),
-        [&](const tbb::blocked_range<uint32_t> &range) {
-            for (uint32_t i = range.begin(); i != range.end(); ++i) {
-                uint32_t nNeighbors = adj[i + 1] - adj[i];
-                uint32_t base = adj[i] - adj[0];
-                for (uint32_t j = 0; j < nNeighbors; ++j) {
-                    uint32_t k = adj[i][j].id;
-                    Float dp = N.col(i).dot(N.col(k));
-                    Float ratio = A[i]>A[k] ? (A[i]/A[k]) : (A[k]/A[i]);
-                    entries[base + j] = Entry(i, k, dp * ratio);
-                }
-            }
-            SHOW_PROGRESS_RANGE(range, V.cols(), "Downsampling graph (1/6)");
-        }
-    );
-
-    if (progress)
-        progress("Downsampling graph (2/6)", 0.0f);
-
-    if (deterministic)
-        pss::parallel_stable_sort(entries, entries + nLinks, std::less<Entry>());
-    else
-        tbb::parallel_sort(entries, entries + nLinks, std::less<Entry>());
-
-    std::vector<bool> mergeFlag(V.cols(), false);
-
-    uint32_t nCollapsed = 0;
-    for (uint32_t i=0; i<nLinks; ++i) {
-        const Entry &e = entries[i];
-        if (mergeFlag[e.i] || mergeFlag[e.j])
-            continue;
-        mergeFlag[e.i] = mergeFlag[e.j] = true;
-        entries[nCollapsed++] = entries[i];
-    }
-    uint32_t vertexCount = V.cols() - nCollapsed;
-
-    /* Allocate memory for coarsened graph */
-    V_p.resize(3, vertexCount);
-    N_p.resize(3, vertexCount);
-    A_p.resize(vertexCount);
-    to_upper.resize(2, vertexCount);
-    to_lower.resize(V.cols());
-
-    tbb::parallel_for(
-        tbb::blocked_range<uint32_t>(0u, (uint32_t) nCollapsed, GRAIN_SIZE),
-        [&](const tbb::blocked_range<uint32_t> &range) {
-            for (uint32_t i = range.begin(); i != range.end(); ++i) {
-                const Entry &e = entries[i];
-                const Float area1 = A[e.i], area2 = A[e.j], surfaceArea = area1+area2;
-                if (surfaceArea > RCPOVERFLOW)
-                    V_p.col(i) = (V.col(e.i) * area1 + V.col(e.j) * area2) / surfaceArea;
-                else
-                    V_p.col(i) = (V.col(e.i) + V.col(e.j)) * 0.5f;
-                Vector3f normal = N.col(e.i) * area1 + N.col(e.j) * area2;
-                Float norm = normal.norm();
-                N_p.col(i) = norm > RCPOVERFLOW ? Vector3f(normal / norm)
-                                                : Vector3f::UnitX();
-                A_p[i] = surfaceArea;
-                to_upper.col(i) << e.i, e.j;
-                to_lower[e.i] = i; to_lower[e.j] = i;
-            }
-            SHOW_PROGRESS_RANGE(range, nCollapsed, "Downsampling graph (3/6)");
-        }
-    );
-
-    delete[] entries;
-
-    std::atomic<int> offset(nCollapsed);
-    tbb::blocked_range<uint32_t> range(0u, (uint32_t) V.cols(), GRAIN_SIZE);
-
-    auto copy_uncollapsed = [&](const tbb::blocked_range<uint32_t> &range) {
-        for (uint32_t i = range.begin(); i != range.end(); ++i) {
-            if (!mergeFlag[i]) {
-                uint32_t idx = offset++;
-                V_p.col(idx) = V.col(i);
-                N_p.col(idx) = N.col(i);
-                A_p[idx] = A[i];
-                to_upper.col(idx) << i, INVALID;
-                to_lower[i] = idx;
-            }
-        }
-        SHOW_PROGRESS_RANGE(range, V.cols(), "Downsampling graph (4/6)");
-    };
-
-    if (deterministic)
-        copy_uncollapsed(range);
-    else
-        tbb::parallel_for(range, copy_uncollapsed);
-
-    VectorXu neighborhoodSize(V_p.cols() + 1);
-
-    tbb::parallel_for(
-        tbb::blocked_range<uint32_t>(0u, (uint32_t) V_p.cols(), GRAIN_SIZE),
-        [&](const tbb::blocked_range<uint32_t> &range) {
-            std::vector<Link> scratch;
-            for (uint32_t i = range.begin(); i != range.end(); ++i) {
-                scratch.clear();
-
-                for (int j=0; j<2; ++j) {
-                    uint32_t upper = to_upper(j, i);
-                    if (upper == INVALID)
-                        continue;
-                    for (Link *link = adj[upper]; link != adj[upper+1]; ++link)
-                        scratch.push_back(Link(to_lower[link->id], link->weight));
-                }
-
-                std::sort(scratch.begin(), scratch.end());
-                uint32_t id = INVALID, size = 0;
-                for (const auto &link : scratch) {
-                    if (id != link.id && link.id != i) {
-                        id = link.id;
-                        ++size;
-                    }
-                }
-                neighborhoodSize[i+1] = size;
-            }
-            SHOW_PROGRESS_RANGE(range, V_p.cols(), "Downsampling graph (5/6)");
-        }
-    );
-
-    neighborhoodSize[0] = 0;
-    for (uint32_t i=0; i<neighborhoodSize.size()-1; ++i)
-        neighborhoodSize[i+1] += neighborhoodSize[i];
-
-    uint32_t nLinks_p = neighborhoodSize[neighborhoodSize.size()-1];
-    AdjacencyMatrix adj_p = new Link*[V_p.size() + 1];
-    Link *links = new Link[nLinks_p];
-    for (uint32_t i=0; i<neighborhoodSize.size(); ++i)
-        adj_p[i] = links + neighborhoodSize[i];
-
-    tbb::parallel_for(
-        tbb::blocked_range<uint32_t>(0u, (uint32_t) V_p.cols(), GRAIN_SIZE),
-        [&](const tbb::blocked_range<uint32_t> &range) {
-            std::vector<Link> scratch;
-            for (uint32_t i = range.begin(); i != range.end(); ++i) {
-                scratch.clear();
-
-                for (int j=0; j<2; ++j) {
-                    uint32_t upper = to_upper(j, i);
-                    if (upper == INVALID)
-                        continue;
-                    for (Link *link = adj[upper]; link != adj[upper+1]; ++link)
-                        scratch.push_back(Link(to_lower[link->id], link->weight));
-                }
-                std::sort(scratch.begin(), scratch.end());
-                Link *dest = adj_p[i];
-                uint32_t id = INVALID;
-                for (const auto &link : scratch) {
-                    if (link.id != i) {
-                        if (id != link.id) {
-                            *dest++ = link;
-                            id = link.id;
-                        } else {
-                            dest[-1].weight += link.weight;
-                        }
-                    }
-                }
-            }
-            SHOW_PROGRESS_RANGE(range, V_p.cols(), "Downsampling graph (6/6)");
-        }
-    );
-    cout << "done. (" << V.cols() << " -> " << V_p.cols() << " vertices, took "
-         << timeString(timer.value()) << ")" << endl;
-    return adj_p;
-}
 
 void generate_graph_coloring_deterministic(const AdjacencyMatrix &adj, uint32_t size,
                              std::vector<std::vector<uint32_t> > &phases,
@@ -390,8 +202,6 @@ void generate_graph_coloring(const AdjacencyMatrix &adj, uint32_t size,
 }
 
 MultiResolutionHierarchy::MultiResolutionHierarchy() {
-    if (sizeof(Link) != 12)
-        throw std::runtime_error("Adjacency matrix entries are not packed! Investigate compiler settings.");
     mA.reserve(MAX_DEPTH+1);
     mV.reserve(MAX_DEPTH+1);
     mN.reserve(MAX_DEPTH+1);
@@ -435,7 +245,7 @@ void MultiResolutionHierarchy::build(bool deterministic, const ProgressCallback 
         VectorXu toLower;
 
         AdjacencyMatrix adj_p =
-            downsample_graph(mAdj[i], mV[i], mN[i], mA[i], V_p, N_p, A_p,
+            AdjacencyMatrix(mAdj[i], mV[i], mN[i], mA[i], V_p, N_p, A_p,
                              toUpper, toLower, deterministic, progress);
 
         if (deterministic)
@@ -513,10 +323,6 @@ void MultiResolutionHierarchy::resetSolution() {
 }
 
 void MultiResolutionHierarchy::free() {
-    for (size_t i=0; i<mAdj.size(); ++i) {
-        delete[] mAdj[i][0];
-        delete[] mAdj[i];
-    }
     mAdj.clear(); mV.clear(); mQ.clear();
     mO.clear(); mN.clear(); mA.clear();
     mCQ.clear(); mCO.clear();
@@ -525,7 +331,10 @@ void MultiResolutionHierarchy::free() {
     mPhases.clear();
     mF.resize(0, 0);
     mE2E.resize(0);
+    mIterationsQ = mIterationsO = -1;
+    mScale = 0;
     mTotalSize = 0;
+    mFrozenO = mFrozenQ = false;
 }
 
 void MultiResolutionHierarchy::save(Serializer &serializer) {
@@ -633,28 +442,7 @@ void MultiResolutionHierarchy::load(const Serializer &serializer) {
         serializer.get("adj_ivar", adj_ivar);
         serializer.get("adj_weight", adj_weight);
 
-        if (adj_id.size() != adj_ivar.size() || adj_ivar.size() != adj_weight.size())
-            throw std::runtime_error("Could not unserialize data");
-        uint32_t linkCount = 0;
-
-        for (uint32_t j=0; j<adj_id.size(); ++j) {
-            if (adj_id[j].size() != adj_ivar[j].size() || adj_ivar[j].size() != adj_weight[j].size())
-                throw std::runtime_error("Could not unserialize data");
-            linkCount += adj_id[j].size();
-        }
-
-        AdjacencyMatrix adj = new Link*[adj_id.size() + 1];
-        adj[0] = new Link[linkCount];
-        for (uint32_t j=0; j<adj_id.size(); ++j)
-            adj[j+1] = adj[j] + adj_id[j].size();
-        for (uint32_t j=0; j<adj_id.size(); ++j) {
-            for (uint32_t k=0; k<adj_id[j].size(); ++k) {
-                adj[j][k].id = adj_id[j][k];
-                adj[j][k].ivar_uint32 = adj_ivar[j][k];
-                adj[j][k].weight = adj_weight[j][k];
-            }
-        }
-        mAdj.push_back(adj);
+        mAdj.emplace_back(AdjacencyMatrix(adj_id, adj_ivar, adj_weight));
         serializer.popPrefix();
     }
 }

--- a/src/hierarchy.h
+++ b/src/hierarchy.h
@@ -18,17 +18,16 @@
 
 class Serializer;
 
-extern AdjacencyMatrix
-downsample_graph(const AdjacencyMatrix adj, const MatrixXf &V,
-                 const MatrixXf &N, const VectorXf &areas, MatrixXf &V_p,
-                 MatrixXf &V_n, VectorXf &areas_p, MatrixXu &to_upper,
-                 VectorXu &to_lower, bool deterministic = false,
-                 const ProgressCallback &progress = ProgressCallback());
-
 struct MultiResolutionHierarchy {
     enum { MAX_DEPTH = 25 };
 public:
     MultiResolutionHierarchy();
+    MultiResolutionHierarchy(const MultiResolutionHierarchy& other) = delete;
+    MultiResolutionHierarchy(MultiResolutionHierarchy&& other) = delete;
+    MultiResolutionHierarchy& operator=(const MultiResolutionHierarchy& other) = delete;
+    MultiResolutionHierarchy& operator=(MultiResolutionHierarchy&& other) = delete;
+    ~MultiResolutionHierarchy(){}
+
     void free();
     void save(Serializer &state);
     void load(const Serializer &state);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
         #endif
 
         {
-            nanogui::ref<Viewer> viewer = new Viewer(fullscreen, deterministic);
+            nanogui::ref<Viewer> viewer = new Viewer(fullscreen, deterministic, nprocs);
             viewer->setVisible(true);
 
             if (args.size() == 1) {

--- a/src/smoothcurve.cpp
+++ b/src/smoothcurve.cpp
@@ -19,9 +19,9 @@
 #include <map>
 #include <set>
 
-bool smooth_curve(const BVH *bvh, const VectorXu &E2E, std::vector<CurvePoint> &curve, bool watertight) {
-    const MatrixXu &F = *bvh->F();
-    const MatrixXf &V = *bvh->V(), &N = *bvh->N();
+bool smooth_curve(const BVH &bvh, const VectorXu &E2E, std::vector<CurvePoint> &curve, bool watertight) {
+    const MatrixXu &F = *bvh.F();
+    const MatrixXf &V = *bvh.V(), &N = *bvh.N();
     cout << endl;
 
     std::vector<CurvePoint> curve_new;
@@ -47,8 +47,8 @@ bool smooth_curve(const BVH *bvh, const VectorXu &E2E, std::vector<CurvePoint> &
                 uint32_t idx1 = 0, idx2 = 0;
                 Float t1 = 0, t2 = 0;
                 Vector2f uv1, uv2;
-                bool hit1 = bvh->rayIntersect(ray1, idx1, t1, &uv1);
-                bool hit2 = bvh->rayIntersect(ray2, idx2, t2, &uv2);
+                bool hit1 = bvh.rayIntersect(ray1, idx1, t1, &uv1);
+                bool hit2 = bvh.rayIntersect(ray2, idx2, t2, &uv2);
 
                 if (!hit1 && !hit2)
                     continue;

--- a/src/smoothcurve.h
+++ b/src/smoothcurve.h
@@ -25,7 +25,7 @@ struct CurvePoint {
 
 class BVH;
 
-extern bool smooth_curve(const BVH *bvh, const VectorXu &E2E,
+extern bool smooth_curve(const BVH &bvh, const VectorXu &E2E,
                          std::vector<CurvePoint> &curve, bool watertight = false);
 
 extern bool astar(const MatrixXu &F, const VectorXu &E2E, const MatrixXf &V,

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -56,7 +56,7 @@ struct CurvePoint;
 
 class Viewer : public Screen {
 public:
-    Viewer(bool fullscreen, bool deterministic);
+    Viewer(bool fullscreen, bool deterministic, int concurrency = -1);
     virtual ~Viewer();
 
     bool mouseMotionEvent(const Vector2i &p, const Vector2i &rel,
@@ -146,7 +146,7 @@ protected:
     VectorXb mBoundaryVertices;
     MultiResolutionHierarchy mRes;
     Optimizer mOptimizer;
-    BVH *mBVH;
+    BVH mBVH;
     MeshStats mMeshStats;
     int mSelectedLevel;
     Float mCreaseAngle;


### PR DESCRIPTION
1. Removed use of raw pointers and data allocated with `new`.  These result in memory leaks if an exception is thrown or if not explicitly deleted by the pointer's recipient.
2. AdjancencyMatrix and BVH classes release their own resources.  They are move constructable and move assignable, but not copy constructable or copy assignable.
3. MultiResolutionHierarchy is no longer responsible for deleting adjacency matrix data.  Also its move and copy constructors and assignment operators are disabled.