### PR TITLE
Fix file dialog not appearing on macOS 15+

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ext/nanogui"]
 	path = ext/nanogui
-	url = https://github.com/wjakob/nanogui
+	url = https://github.com/AngryAnt3201/nanogui
 [submodule "ext/pcg32"]
 	path = ext/pcg32
 	url = https://github.com/wjakob/pcg32


### PR DESCRIPTION
## Summary
- On macOS 15+ (Sequoia/Tahoe), `NSSavePanel`/`NSOpenPanel`'s `runModal` and `beginWithCompletionHandler:` both silently fail when called from inside a GLFW event callback — `runModal` returns `NSModalResponseCancel` instantly, and `beginWithCompletionHandler:` never fires its completion block
- Updates bundled nanogui to use an `osascript`-based file dialog that runs in a separate process, bypassing the GLFW/Cocoa run loop conflict entirely
- Also fixes GLFW's `CMakeLists.txt` for CMake 4.x compatibility (`cmake_minimum_required` bump and `CMP0042` policy fix)

## Details

The root cause is a conflict between GLFW's event loop and the nested/cooperative modal run loops that `NSSavePanel`/`NSOpenPanel` require on macOS 15+. Apple changed modal dialog handling in Sequoia such that panels created during a GLFW `sendEvent:` callback are silently suppressed.

The fix shells out to `/usr/bin/osascript` with an AppleScript `choose file` / `choose file name` command, which opens the native macOS file dialog in a separate process and returns the selected path via stdout.

## Test plan
- [x] Verified file open dialog appears and returns correct path on macOS 26.x (Tahoe)
- [ ] Verify file save/export dialog works
- [ ] Verify no regression on macOS 14.x (Sonoma) and earlier
- [ ] Verify CMake 4.x builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)